### PR TITLE
update 404 page to include return to home button

### DIFF
--- a/overview/pages/404.vue
+++ b/overview/pages/404.vue
@@ -6,8 +6,10 @@
 
         <h1 style="color:#bf3f4a">404: Page Not Found</h1>
 
-        <p>Oops! It looks like you've wandered onto a non-existent page.
-         Check the URL that sent you here and try again.</p>
+        <p>Oops! It looks like you've wandered onto a non-existent page.</p>
+        <br>
+        <nuxt-link to="/"><v-btn color="primary">Back to Home Page</v-btn></nuxt-link>
+        <br>
         <br>
         <p>Or don't. I'm an error page, not your boss.</p>
 


### PR DESCRIPTION
The change in the code is pretty simple but the real valuable change was changing the error rendering path in our Cloudfront account so the 404 error is actually rendered instead of an ugly 'page cannot load' error page.  I pushed this branch to staging already to test it and if you test any invalid URL path in production now (example: https://covid-watch.org/yomama), it renders the 404 error page (that doesn't currently have a 'back to home page' button.

**Before**

![Screen Shot 2020-04-08 at 9 53 58 PM](https://user-images.githubusercontent.com/16062590/78854232-c4d9b200-79ee-11ea-90aa-76d687a9b8ff.png)

**After**

- 404 page renders as expected
- Large, clear 'Back to Home Page' button added to 404 page

![Screen Shot 2020-04-08 at 11 13 19 PM](https://user-images.githubusercontent.com/16062590/78854250-d02cdd80-79ee-11ea-928c-5938a1b8ab5c.png)

