### PR TITLE
styling consistency updates and added alert to home page

### DIFF
--- a/overview/pages/about.vue
+++ b/overview/pages/about.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row justify="center">
-      <v-col cols="12" lg="8">
+      <v-col cols="12" lg="10">
         <section class="text-content">
           <div class="container">
             <div class="blog-hero"></div>

--- a/overview/pages/blog/bluetooth.vue
+++ b/overview/pages/blog/bluetooth.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row justify="center">
-      <v-col cols="12" lg="8">
+      <v-col cols="12" lg="10">
         <div class="blog-hero">
           <h1>Bluetooth Primer: 7th of March 2020</h1>
         </div>

--- a/overview/pages/blog/index.vue
+++ b/overview/pages/blog/index.vue
@@ -1,30 +1,20 @@
 <template>
   <v-container>
+      <v-row >
+        <v-col class="d-flex justify-end" cols="12" lg="10">
+          <nuxt-link to="/press_releases">Press Releases</nuxt-link>
+        </v-col>
+      </v-row>
+
     <v-row justify="center">
-      <v-col cols="12" lg="8">
+      <v-col cols="12" lg="10">
         <section class="text-content">
           <div class="container">
+            <h1 style="color:#BF3F4A">Blog</h1>
+            <br>
             <div class="blog-hero">
-              <h1 style="color:#BF3F4A">Blog Posts</h1>
 
-              <div class="blog-item">
-                <div class="blog-item-content">
-                  <h2>Press Release: 10th of March 2020</h2>
-
-                  <p>
-                    <strong>Covid Watch in Support of Apple and Google’s Digital Contact Tracing Partnership Announcement</strong> 
-                  </p>
-
-                  <p>
-                    Covid Watch, a non-profit, in collaboration with Stanford University, has been working for two months now on a contact tracing protocol that will protect users' privacy while tracing the spread of Covid-19. Today, the world’s tech giants joined that mission.
-                  <p>
-                    <nuxt-link class="read-more" to="/blog/press_release"
-                    >Read Full Press Release...</nuxt-link
-                    >
-                  </p>
-                </div>
-              </div>
-
+           
               <div class="blog-item">
                 <div class="blog-item-content">
                   <h2>Progress Post: 29th of March 2020</h2>
@@ -163,24 +153,24 @@
                 <div class="blog-item-content">
                   <h2>Progress Post: 27th of February 2020</h2>
 
-                  <div class="blog-item-excerpt">
-                    Phew! What a week.<br />
+                  <p>
+                    Phew! What a week.<br>
                     We&rsquo;ve gone from two researchers and a
-                    <b
-                      ><a
-                        href="https://forum.effectivealtruism.org/posts/8chk6DHZXctGHtNoz/covid-19-risk-assessment-app-idea-for-vetting-and-discussion"
-                        >forum post</a
-                      ></b
-                    >
+                    
+                    <a href="https://forum.effectivealtruism.org/posts/8chk6DHZXctGHtNoz/covid-19-risk-assessment-app-idea-for-vetting-and-discussion">
+                      forum post
+                    </a>
+                    
                     to a team of over a dozen, with expert academic advice and
-                    support rolling in.<br />
-                    As you may expect...
-                  </div>
-                  <nuxt-link class="read-more" to="/blog/progress1"
-                    >Read More...</nuxt-link
-                  >
+                    support rolling in. As you may expect, much of our effort has gone into keeping on top of the organisational aspects of the project: onboarding new members...
+                  </p>
+                  <nuxt-link class="read-more" to="/blog/progress1">
+                    Read More...
+                  </nuxt-link>
+                  
                 </div>
               </div>
+
             </div>
           </div>
         </section>

--- a/overview/pages/blog/insight1.vue
+++ b/overview/pages/blog/insight1.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row justify="center">
-      <v-col cols="12" lg="8">
+      <v-col cols="12" lg="10">
         <div class="blog-hero">
           <!---<img src="images/blog-image.jpg" alt="Full width blog image" /> --->
           <h1>Insight Post: 28th of February 2020</h1>

--- a/overview/pages/blog/insight2.vue
+++ b/overview/pages/blog/insight2.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row justify="center">
-      <v-col cols="12" lg="8">
+      <v-col cols="12" lg="10">
         <div class="blog-hero">
           <h1>Insight Post: 6th of March 2020</h1>
         </div>

--- a/overview/pages/blog/optimism.vue
+++ b/overview/pages/blog/optimism.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row justify="center">
-      <v-col cols="12" lg="8">
+      <v-col cols="12" lg="10">
         <section class="text-content">
           <div class="container">
             <div class="blog-hero"></div>

--- a/overview/pages/blog/progress1.vue
+++ b/overview/pages/blog/progress1.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row justify="center">
-      <v-col cols="12" lg="8">
+      <v-col cols="12" lg="10">
         <div class="blog-hero">
           <!--- <img src="images/blog-image.jpg" alt="Full width blog image" />-->
           <h1>Progress Post: 27th of February 2020</h1>

--- a/overview/pages/blog/progress2.vue
+++ b/overview/pages/blog/progress2.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row justify="center">
-      <v-col cols="12" lg="8">
+      <v-col cols="12" lg="10">
         <div class="blog-hero">
           <!--- <img src="images/blog-image.jpg" alt="Full width blog image" />-->
           <h1>Progress Post: 4th of March 2020</h1>

--- a/overview/pages/blog/progress3.vue
+++ b/overview/pages/blog/progress3.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row justify="center">
-      <v-col cols="12" lg="8">
+      <v-col cols="12" lg="10">
         <div class="blog-hero">
           <!--- <img src="images/blog-image.jpg" alt="Full width blog image" />-->
           <h1>Progress Post: 29th of March 2020</h1>

--- a/overview/pages/collaborate.vue
+++ b/overview/pages/collaborate.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row justify="center">
-      <v-col cols="12" lg="8">
+      <v-col cols="12" lg="10">
         <section class="text-content">
           <div class="container">
             <div class="blog-hero"></div>

--- a/overview/pages/donate.vue
+++ b/overview/pages/donate.vue
@@ -1,8 +1,10 @@
 <template>
   <v-container>
     <v-row justify="center">
-      <v-col cols="12" lg="8">
-        <h2>Donations</h2>
+      <v-col cols="12" lg="10">
+        <h1 style="color:#BF3F4A">Donations</h1>
+        <br>
+
         <p>
           NOTE: All donations are denominated in USD. The checkout page may take several seconds to load. 
         </p>

--- a/overview/pages/faq.vue
+++ b/overview/pages/faq.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row justify="center">
-      <v-col cols="12" lg="8">
+      <v-col cols="12" lg="10">
         <section class="text-content">
           <div class="container">
             <div class="blog-hero"></div>
@@ -47,6 +47,13 @@
               the painful impacts of COVID-19. That’s what all of the people working on this project
               were looking for, and we hope that users who participate in COVID Watch will feel they
               have been given a tool with which to protect their community and loved ones.
+            </p>
+
+
+            <h3>Aren’t Google and Apple working on something similar?</h3>
+            <br>
+            <p>
+              There are! We have been in contact with them since late March 2020.  You can read our full perspective on their efforts in our  <nuxt-link to="/press_releases/google_apple_press_release">April 10, 2020 press release here</nuxt-link> .
             </p>
 
             <h3>Aren’t there a lot of people working on this already?</h3>
@@ -309,6 +316,12 @@
               We’re reaching out to the CDC to give us permission numbers to validate self-reports,
               so we don’t send out false positives. We’re also going to start reaching out to state
               health agencies since they keep state records with their confirmation numbers as well.
+            </p>
+
+            <h3>How can I get involved?</h3>
+            <br>
+            <p>
+              We are always looking for talented people worldwide to join this effort as volunteers.  See our <nuxt-link to="/collaborate">Join Our Team page</nuxt-link> for the roles we are looking to fill and how to join our group.
             </p>
 
 

--- a/overview/pages/index.vue
+++ b/overview/pages/index.vue
@@ -2,6 +2,24 @@
   <v-container>
     <v-row justify="center">
       <v-col cols="12" lg="10">
+        <v-row align="center" justify="center">
+            <nuxt-link  to="/press_releases/google_apple_press_release">
+              <v-hover v-slot:default="{ hover }" > 
+                <v-alert 
+                  outlined 
+                  dense 
+                  dismissable 
+                  color="info" 
+                  type="info"
+                  :elevation="hover ? 2 : 0"
+                  :class="{ 'on-hover': hover }"
+                  class="d-flex pa-2 mx-10"
+                  >
+                    Read our press release: "Covid Watch Celebrates Apple and Google’s COVID-19 Contact Tracing Announcement"
+                  </v-alert>
+              </v-hover>
+            </nuxt-link>
+        </v-row>
         <v-row align="center">
           <v-col cols="12" sm="5" class="hand_image">
             <img

--- a/overview/pages/medialist.vue
+++ b/overview/pages/medialist.vue
@@ -1,9 +1,12 @@
 <template>
-  <v-container>
+  <v-container class="mediaList">
+    <v-row >
+      <v-col class="d-flex justify-end" cols="12" lg="10">
+        <nuxt-link to="/press_releases">Press Releases</nuxt-link>
+      </v-col>
+    </v-row>
     <v-row justify="center">
       <v-col cols="12" lg="10">
-
-
         <h1 style="color:#bf3f4a">Media Coverage</h1>
         <br>
 
@@ -15,7 +18,7 @@
             <br />
             <span class="title"><a target="_blank" :href="media.href">{{ media.title }}</a></span>
             <br />
-            <span v-html="media.credit"></span>.
+            <span class="credit" v-html="media.credit"></span>.
           </div>
         </template>
 
@@ -46,6 +49,8 @@
     </v-row>
   </v-container>
 </template>
+
+
 
 <script>
   import SubscribeForm from '../components/SubscribeForm.vue'

--- a/overview/pages/press_releases/google_apple_press_release.vue
+++ b/overview/pages/press_releases/google_apple_press_release.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container>
     <v-row justify="center">
-      <v-col cols="12" lg="8">
+      <v-col cols="12" lg="10">
         <section class="text-content">
           <div class="container">
             <nuxt-link to="/press_releases">Back to Press Releases</nuxt-link>
@@ -70,7 +70,7 @@
             </p>
 
             <br>
-            
+
             <p><strong>Contact:</strong></p>
             <p>Rhys Fenwick, PR/Communications</p> 
             <p>


### PR DESCRIPTION
- added alert banner to home screen advertising google/apple press release
- removed press release content from /blog page
- added links to press releases page from /blog and /medialist
- adjusted general consistency of styling on pages (ex: h1 elements at top of each page instead of mix of h1, h2, and h3)

![Screen Shot 2020-04-10 at 9 37 14 PM](https://user-images.githubusercontent.com/16062590/79033545-f54f5680-7b7c-11ea-8c69-d0eaebf2ca03.png)

I played with adding "Press Releases" to the header but it seemed to me to be getting too crowded so I opted to link to /press_releases from /blog and /medialist, thinking that in many cases the direct link will be shared w journalists, etc. and an alert on the home page for a week or so will direct any ppl there for whom it's relevant.

See how crowded header looks with "Press Releases" there:

![Screen Shot 2020-04-10 at 9 41 01 PM](https://user-images.githubusercontent.com/16062590/79033562-1b74f680-7b7d-11ea-9e6f-180504dcdcc2.png)

