### PR TITLE
v1 of FAQ table of contents

### DIFF
--- a/overview/components/FAQTableOfContents.vue
+++ b/overview/components/FAQTableOfContents.vue
@@ -1,0 +1,103 @@
+<template>
+  <span id="FAQtableOfContents">
+    <div class="FAQtableOfContentsContainer">
+      <h2 class="titleLine">FAQ Navigator</h2>
+      <ol class="outerList">
+        <li>
+          <a href="/faq#who-are-you">Who are you?</a>
+        </li>
+        <li>
+          <a href="/faq#why-do-this">Why are you doing this?</a>
+        </li>
+        <li>
+          <a href="/faq#google-and-apple">Aren’t Google and Apple working on something similar?</a>
+        </li>
+        <li>
+          <a href="/faq#what-is-contact-tracing">What is contact tracing?</a>
+        </li>
+        <li>
+          <a href="/faq#delay-inevitable">If COVID-19 is going to become widespread anyway, why bother delaying the inevitable?</a>
+        </li>
+        <li>
+          <a href="/faq#lockdown-why">There is already a lockdown in my country / state and we can’t meet other people, so what is the point?</a>
+        </li>
+        <li>
+          <a href="/faq#health-privacy">Is this legal given health data privacy laws?</a>
+        </li>
+        <li>
+          <a href="/faq#traction">Will this app ever get enough traction to work?</a>
+        </li>
+        <li>
+          <a href="/faq#another-app">Is this just another app that will record my symptoms?</a>
+        </li>
+        <li>
+          <a href="/faq#asian-countries">Is this similar to what South Korea, Taiwan, and Singapore are doing?</a>
+        </li>
+        <li>
+          <a href="/faq#hong-kong">Is this the same as what Hong Kong has introduced?</a>
+        </li>
+        <li>
+          <a href="/faq#legal-status">What is the legal status of your organization?</a>
+        </li>
+        <li>
+          <a href="/faq#data-collection">What data are you collecting?</a>
+        </li>
+        <li>
+          <a href="/faq#data-ownership">Who owns the data that is collected and will you sell it?</a>
+        </li>
+        <li>
+          <a href="/faq#bluetooth">Why are you using Bluetooth?</a>
+        </li>
+        <li>
+          <a href="/faq#gps">Why not use GPS as well?</a>
+        </li>
+        <li>
+          <a href="/faq#snoop-dogg">Will this app snoop on me?</a>
+        </li>
+        <li>
+          <a href="/faq#finished">How close to finished is the app?</a>
+        </li>
+        <li>
+          <a href="/faq#exposed">Will this app tell me where or when I was exposed?</a>
+        </li>
+        <li>
+          <a href="/faq#collaborators">Who are your app’s collaborators? Are you working with the government?</a>
+        </li>
+        <li>
+          <a href="/faq#get-involved">How can I get involved?</a>
+        </li>
+        
+      </ol>
+    </div>
+  </span>
+</template>
+
+<style lang="scss">
+#FAQtableOfContents {
+  display: flex;
+  justify-content: baseline;
+  width: 100%;
+  // padding-top: 50px;
+  // border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  // padding-bottom: 40px;
+
+  .FAQtableOfContentsContainer {
+    // border: gray 1px solid;
+    // margin-left: 1vw;
+    // border-radius: 4px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    .outerList {
+      list-style: none;
+      // font-size: 22px;
+
+      li {
+          padding: 12px;
+      }
+    }
+
+  }
+}
+</style>

--- a/overview/layouts/default.vue
+++ b/overview/layouts/default.vue
@@ -84,6 +84,27 @@
       <TableOfContents></TableOfContents>
     </v-navigation-drawer>
 
+    <!-- Navigation drawer (i.e. Table of Contents) for the FAQ page --->
+    <v-navigation-drawer
+      v-if="$nuxt.$route.name === 'faq'"
+      clipped
+      app
+      :width="350"
+      v-model="tocShow"
+    >
+      <v-btn
+        icon
+        small
+        color="primary"
+        class="toc-closer"
+        @click="tocShow = !tocShow"
+      >
+        <v-icon>mdi-close-circle</v-icon>
+      </v-btn>
+
+      <FAQTableOfContents></FAQTableOfContents>
+    </v-navigation-drawer>
+
     <v-content>
       <!-- Affiliations --->
       <v-row align="center" justify="center" no-gutters>
@@ -116,6 +137,17 @@
           <v-divider></v-divider>
         </v-col>
       </v-row>
+
+        <!-- Button to show / hide table of contents --->
+      <v-btn
+        v-if="$nuxt.$route.name === 'faq'"
+        class="toc-hamburger"
+        color="primary"
+        v-show="!tocShow"
+        @click="tocShow = !tocShow"
+      >
+        <v-icon>mdi-table-of-contents</v-icon>
+      </v-btn>
 
       <!-- Button to show / hide table of contents --->
       <v-btn
@@ -212,6 +244,7 @@
   width: 30% !important;
 }
 
+
 h1 {
   font-size: 36px;
 }
@@ -221,6 +254,7 @@ h1 {
 
 <script>
 import TableOfContents from "~/components/TableOfContents.vue";
+import FAQTableOfContents from "~/components/FAQTableOfContents.vue";
 
 export default {
   data: () => ({
@@ -281,7 +315,8 @@ export default {
     ]
   }),
   components: {
-    TableOfContents
+    TableOfContents,
+    FAQTableOfContents
   }
 };
 </script>

--- a/overview/pages/faq.vue
+++ b/overview/pages/faq.vue
@@ -9,6 +9,16 @@
             <h1 style="color:#BF3F4A">Frequently Asked Questions</h1>
             <br>
 
+
+            <!-- Jesse note: 
+            
+            I started to use the code below but ran into some challenges that we can update later.  For refactoring:
+            - nuxt-links can't be stored in the faqList object
+            - vertical spacing between <p> elements in a single faq.response
+             -->
+
+
+
             <!-- <template
               v-for="(faq, i) in faqList"
             >

--- a/overview/pages/faq.vue
+++ b/overview/pages/faq.vue
@@ -9,7 +9,18 @@
             <h1 style="color:#BF3F4A">Frequently Asked Questions</h1>
             <br>
 
-            <h3>Who are you?</h3>
+            <!-- <template
+              v-for="(faq, i) in faqList"
+            >
+              <div :key="i">
+                <h3>{{faq.question}}</h3>
+                <p>{{faq.response}}</p>
+              </div>
+            </template>
+
+            <h1 style="color:red;">division here</h1> -->
+
+            <h3 id="who-are-you">Who are you?</h3>
             <br>
 
             <p>
@@ -21,25 +32,14 @@
             </p>
 
 
-            <h3>Why are you doing this?</h3>
+            <h3 id="why-do-this">Why are you doing this?</h3>
             <br>
             <p>
-              We don’t expect a COVID-19 vaccine to be developed for at least a year,
-              which means we must build a system that is capable of rapidly containing
-              local transmission wherever and whenever it appears. By doing this, and
-              implementing it in our communities, we can lessen lockdowns and other
-              restrictions in the world while preventing the majority of the population
-              from getting sick.
+              We don’t expect a COVID-19 vaccine to be developed for at least a year, which means we must build a system that is capable of rapidly containing local transmission wherever and whenever it appears. By doing this, and implementing it in our communities, we can lessen lockdowns and other restrictions in the world while preventing the majority of the population from getting sick.
             </p>
 
             <p>
-              If we build a system that can identify contagious individuals and the people
-              they had contact with, then we can ask only those who have been exposed to COVID-19
-              to self-isolate. We’ve modelled how such a system can significantly reduce
-              the rate of viral transmission; check out our <nuxt-link to="/article">whitepaper</nuxt-link>.
-              We believe that,
-              combined with a comprehensive testing program, our filter may be powerful enough
-              to protect our communities from COVID-19 becoming endemic.
+              If we build a system that can identify contagious individuals and the people they had contact with, then we can ask only those who have been exposed to COVID-19 to self-isolate. We’ve modelled how such a system can significantly reduce the rate of viral transmission; check out our <nuxt-link to="/article">whitepaper</nuxt-link>. We believe that, combined with a comprehensive testing program, our filter may be powerful enough to protect our communities from COVID-19 becoming endemic.
             </p>
 
             <p>
@@ -50,7 +50,7 @@
             </p>
 
 
-            <h3>Aren’t Google and Apple working on something similar?</h3>
+            <h3 id="google-and-apple">Aren’t Google and Apple working on something similar?</h3>
             <br>
             <p>
               There are! We have been in contact with them since late March 2020.  You can read our full perspective on their efforts in our  <nuxt-link to="/press_releases/google_apple_press_release">April 10, 2020 press release here</nuxt-link> .
@@ -66,7 +66,7 @@
 
             </p>
 
-            <h3>What is contact tracing?</h3>
+            <h3 id="what-is-contact-tracing">What is contact tracing?</h3>
             <br>
             <p>
               The World Health Organisation (WHO) <a href="https://www.who.int/features/qa/contact-tracing/en/">defines</a>
@@ -96,7 +96,7 @@
               contact tracing.
             </p>
 
-            <h3>If COVID-19 is going to become widespread anyway, why bother delaying the inevitable?</h3>
+            <h3 id="delay-inevitable">If COVID-19 is going to become widespread anyway, why bother delaying the inevitable?</h3>
             <br>
             <p>
               It’s not inevitable that COVID-19 will spread to every person, and slowing the spread is still
@@ -108,7 +108,7 @@
               the severe negative economic consequences of COVID-19 that are materialising around the world.
             </p>
 
-            <h3>There is already a lockdown in my country / state and we can’t meet other people, so what is the point?</h3>
+            <h3 id="lockdown-why">There is already a lockdown in my country / state and we can’t meet other people, so what is the point?</h3>
             <br>
             <p>
               We want to help bring you out of lockdown. Right now, the virus is spreading rapidly, and we must
@@ -133,7 +133,7 @@
               as one of the strategies that he believed could bring the pandemic under control.
             </p>
 
-            <h3>Is this legal given health data privacy laws?</h3>
+            <h3 id="health-privacy">Is this legal given health data privacy laws?</h3>
             <br>
             <p>
               Yes.
@@ -148,7 +148,7 @@
               laws for the regions in which the app is available.
             </p>
 
-            <h3>Will this app ever get enough traction to work?</h3>
+            <h3 id="traction">Will this app ever get enough traction to work?</h3>
             <br>
             <p>
               We don’t know, but it might need less traction than you imagine. Our modelling suggests
@@ -158,7 +158,7 @@
               made by Covid Watch will benefit many projects.
             </p>
 
-            <h3>Is this just another app that will record my symptoms?</h3>
+            <h3 id="another-app">Is this just another app that will record my symptoms?</h3>
             <br>
             <p>
               No. Our main purpose is local containment. Covid Watch alerts users if they may have been
@@ -166,7 +166,7 @@
               symptom screening apps, that is not our initial aim.
             </p>
 
-            <h3>Is this similar to what South Korea, Taiwan, and Singapore are doing?</h3>
+            <h3 id="asian-countries">Is this similar to what South Korea, Taiwan, and Singapore are doing?</h3>
             <br>
             <p>
               No.
@@ -187,7 +187,7 @@
               share their health information, they are never forced to.
             </p>
 
-            <h3>Is this the same as what Hong Kong has introduced?</h3>
+            <h3 id="hong-kong">Is this the same as what Hong Kong has introduced?</h3>
             <br>
             <p>
               No.
@@ -200,7 +200,7 @@
               are stored on your own device; the aim is to enable contact-tracing in a way that preserves privacy.
             </p>
 
-            <h3>What is the legal status of your organization?</h3>
+            <h3 id="legal-status">What is the legal status of your organization?</h3>
             <br>
             <p>
               We are a registered non-profit in the US state of Arizona. We have submitted the required
@@ -210,7 +210,7 @@
               tax deductible, charitable contributions.
             </p>
 
-            <h3>What data are you collecting?</h3>
+            <h3 id="data-collection">What data are you collecting?</h3>
             <br>
             <p>
               Anonymized contact event numbers are stored locally on your phone. If you are diagnosed with
@@ -231,7 +231,7 @@
               been exposed.
             </p>
 
-            <h3>Who owns the data that is collected and will you sell it?</h3>
+            <h3 id="data-ownership">Who owns the data that is collected and will you sell it?</h3>
             <br>
             <p>
               The data is anonymized and we will not sell what is uploaded to the database. It wouldn’t be worth anything,
@@ -240,7 +240,7 @@
               Data from old events will also be deleted every 2-3 weeks.
             </p>
 
-            <h3>Why are you using Bluetooth?</h3>
+            <h3 id="bluetooth">Why are you using Bluetooth?</h3>
             <br>
             <p>
               When we first thought about a smartphone contact tracing app, we imagined using GPS location tracking.
@@ -251,7 +251,7 @@
               about this in our whitepaper.
             </p>
 
-            <h3>Why not use GPS as well?</h3>
+            <h3 id="gps">Why not use GPS as well?</h3>
             <br>
             <p>
               We have decided not to implement this unless we are confident we can do so in a way that preserves
@@ -275,7 +275,7 @@
 
             </p>
 
-            <h3>Will this app snoop on me?</h3>
+            <h3 id="snoop-dogg">Will this app snoop on me?</h3>
             <br>
             <p>
               One of the key reasons we started Covid Watch is that we were worried that a contact tracing solution
@@ -285,16 +285,16 @@
               other contact tracing projects.
             </p>
 
-            <h3>How close to finished is the app?</h3>
+            <h3 id="finished">How close to finished is the app?</h3>
             <br>
             <p>
               We are currently at the beta-testing stage for our Bluetooth contact tracing app
               on both Android and iOS, and are actively in talks with the CDC and other health
               agencies internationally. With our current timeline, we aim to have a usable app
-              finalised by the second week of April at the latest.
+              finalised by the end of April at the latest.
             </p>
 
-            <h3>Will this app tell me where or when I was exposed?</h3>
+            <h3 id="exposed">Will this app tell me where or when I was exposed?</h3>
             <br>
             <p>
               No. Since we don’t collect any location data, we can’t tell you where you were exposed
@@ -308,7 +308,7 @@
                is anonymous enough that any downsides are outweighed by the benefits of the system.
             </p>
 
-            <h3>Who are your app’s collaborators? Are you working with the government?</h3>
+            <h3 id="collaborators">Who are your app’s collaborators? Are you working with the government?</h3>
             <br>
             <p>
               A critical part of Covid Watch is buy-in from some relevant healthcare authorities.
@@ -318,7 +318,7 @@
               health agencies since they keep state records with their confirmation numbers as well.
             </p>
 
-            <h3>How can I get involved?</h3>
+            <h3 id="get-involved">How can I get involved?</h3>
             <br>
             <p>
               We are always looking for talented people worldwide to join this effort as volunteers.  See our <nuxt-link to="/collaborate">Join Our Team page</nuxt-link> for the roles we are looking to fill and how to join our group.
@@ -331,3 +331,20 @@
     </v-row></v-container
   >
 </template>
+
+<script>
+export default {
+  data: () => ({
+    faqList: [
+      {
+        "question": "Who are you?",
+        "response": "We’re a non-profit group of researchers, programmers security experts and public health professionals. Starting from a forum post on February 19, our team, led by researchers from Stanford University and the University of Waterloo, has grown to a group of around 10-15 core contributors, as well as many more part-time volunteers and advisors. Although we are aiming to develop an app for initial use in the USA, the team is based around the world.",
+      },
+      {
+        "question": "Why are you doing this?",
+        "response": "We don’t expect a COVID-19 vaccine to be developed for at least a year, which means we must build a system that is capable of rapidly containing local transmission wherever and whenever it appears. By doing this, and implementing it in our communities, we can lessen lockdowns and other restrictions in the world while preventing the majority of the population from getting sick.",
+      }
+    ]
+  })
+}
+</script>


### PR DESCRIPTION
- Added a collapsable Table of Contents to navigate the FAQ questions, just like exists in the Whitepaper page.

Open to feedback on styling, etc.  These aren't yet cards and the code itself is not very DRY but it gets the job done to ship this quickly.  We can refactor to make look nicer/take advantage of Vuetify more later if we want.

![Screen Shot 2020-04-11 at 8 46 49 PM](https://user-images.githubusercontent.com/16062590/79057996-cf39bd00-7c35-11ea-8b8a-f7d4cfe3ac6d.png)
