### PR TITLE
[tiny] Banner logo is not cut off on the left side

### DIFF
--- a/overview/layouts/default.vue
+++ b/overview/layouts/default.vue
@@ -15,6 +15,7 @@
             class="logoImg"
             :src="require('../assets/images/logo/banner_1.png')"
             alt="Covid Watch"
+            contain
           />
         </a>
         <a class="logoMobile logo d-flex d-md-none" href="#">


### PR DESCRIPTION
Addresses [this Trello task](https://trello.com/c/Zt5Rp2pz/112-victoria-noted-the-banner-logo-is-cut-off-fix-this). Turned out to be a simple fix. Also, this bug didn't appear in Firefox, which explains why I didn't notice it when I was first updating the toolbar...

### Screenshots

![image](https://user-images.githubusercontent.com/7595169/79252037-daf3d200-7e35-11ea-9917-53a5f0e0ade2.png)
![image](https://user-images.githubusercontent.com/7595169/79252057-e1824980-7e35-11ea-8b13-ab7ca0b1e0d4.png)
